### PR TITLE
Separate unit tests from Docker build

### DIFF
--- a/.github/workflows/ci2.yaml
+++ b/.github/workflows/ci2.yaml
@@ -1,12 +1,8 @@
-name: Open Data Access Tools for OEDI
+name: Docker Actions
 on:
   push:
     branches:
-    - integration
-  pull_request:
-    branches:
     - master
-    - integration
 
 jobs:
   build:
@@ -37,4 +33,22 @@ jobs:
       run: |
         export AWS_DEFAULT_REGION=us-west-2
         pytest tests/unit
-
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Pull oedi version for tag
+      id: vtag
+      run: echo "::set-output name=docker_tag::$(python setup.py -V)"
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile
+        push: true
+        tags: |
+          ${{ secrets.DOCKERHUB_ORGNAME }}/oedi:${{ steps.vtag.outputs.docker_tag }}
+          ${{ secrets.DOCKERHUB_ORGNAME }}/oedi:latest


### PR DESCRIPTION
ci.yaml performs unit tests on push to integration as well as pull request to master or integration.
ci2.yaml will perform unit tests as well as build and push new image to docker hub but only on push to master.